### PR TITLE
fix: user level CSS selector

### DIFF
--- a/scplus2_selectors.js
+++ b/scplus2_selectors.js
@@ -2,7 +2,7 @@ window.scplus2 = window.scplus2 || {};
 
 scplus2.selectors = {
     // Profile Page
-    user_xp: `._e514c49d68c8 > div:first-child`, // the div containing the raw text showing the xp
+    user_xp: `.user-level-profile > div`, // the div containing the raw text showing the xp
 
     // Header
     sticky_user: `._d2d1faad5aaa .user-block`, // the bottom most container of the sticky header user elements


### PR DESCRIPTION
The previous way was getting some dynamic selectors, making it so it disappeared whenever the selector changed. Now, we are checking directly the div class name.

Resolves #5 